### PR TITLE
if there are more than 10 labels in the heatmap for a given legend en…

### DIFF
--- a/R/colorbars.R
+++ b/R/colorbars.R
@@ -133,24 +133,31 @@ setMethod("make_colorbar",
             w <- (n - 1) / n
 
             # Handle high-cardinality categorical variables to prevent overlap
+            # Configuration constants for legend label management
+            MAX_LABELS_THRESHOLD <- 10    # Show all labels if n <= this value
+            TARGET_LABEL_COUNT <- 8       # Approximate number of labels to show when sparse
+            MIN_ABBREV_LENGTH <- 4        # Minimum length for abbreviation
+            MAX_LABEL_LENGTH <- 10        # Max chars before truncation
+            TRUNCATE_LENGTH <- 8          # Length to truncate long labels to
+
             display_ticktext <- if (n == 1) {
               as.list(cb@ticktext)
-            } else if (n > 10) {
+            } else if (n > MAX_LABELS_THRESHOLD) {
               # Show subset of labels with spacing to prevent overlap
-              step <- ceiling(n / 8)  # Show approximately 8 evenly spaced labels
+              step <- ceiling(n / TARGET_LABEL_COUNT)
               show_indices <- seq(1, n, by = step)
               sparse_text <- rep("", n)
 
               # Try abbreviation first (on all labels to detect patterns)
               all_abbreviated <- as.character(abbreviate(cb@ticktext,
-                                                       minlength = 4,
+                                                       minlength = MIN_ABBREV_LENGTH,
                                                        use.classes = FALSE))
               selected_labels <- all_abbreviated[show_indices]
 
               # If abbreviation didn't shorten much, use substring instead
               for (i in seq_along(selected_labels)) {
-                if (nchar(selected_labels[i]) > 10) {
-                  selected_labels[i] <- substr(cb@ticktext[show_indices[i]], 1, 8)
+                if (nchar(selected_labels[i]) > MAX_LABEL_LENGTH) {
+                  selected_labels[i] <- substr(cb@ticktext[show_indices[i]], 1, TRUNCATE_LENGTH)
                 }
               }
 


### PR DESCRIPTION
.…try, start showing a subset of them so they do not overlap on screen

This pull request introduces an improvement to the colorbar rendering logic for categorical variables in the `make_colorbar` method within `R/colorbars.R`. The main change focuses on handling cases with a high number of categories to prevent label overlap.

Enhancements for high-cardinality categorical colorbars:

* Added logic to display a sparse subset of tick labels when the number of categories exceeds 10, using abbreviations or truncated substrings to keep labels concise and readable