### PR TITLE
Fix: Prevent graphics device opening during dendrogram creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ inst/doc
 .Rhistory
 /doc/
 /Meta/
+Rplots.pdf

--- a/R/dendogram.R
+++ b/R/dendogram.R
@@ -1,7 +1,13 @@
-dendro_to_coords <- function(dendro, 
+dendro_to_coords <- function(dendro,
                              orientation = c("left","bottom","right","top")){
 
   orientation <- match.arg(orientation)
+
+  # Suppress graphics device opening (ggdendro can trigger device creation)
+  old_device <- getOption("device")
+  options(device = function(...) pdf(file = nullfile()))
+  on.exit(options(device = old_device), add = TRUE)
+
   d <- ggdendro::dendro_data(dendro)$segments
   shapes <- vector("list", nrow(d))
 

--- a/R/dendogram.R
+++ b/R/dendogram.R
@@ -3,10 +3,10 @@ dendro_to_coords <- function(dendro,
 
   orientation <- match.arg(orientation)
 
-  # Suppress graphics device opening (ggdendro can trigger device creation)
-  old_device <- getOption("device")
-  options(device = function(...) pdf(file = nullfile()))
-  on.exit(options(device = old_device), add = TRUE)
+  # Prevent graphics device opening by using a null device
+  # ggdendro::dendro_data() triggers device creation - open null device first
+  pdf(NULL)
+  on.exit(dev.off(), add = TRUE)
 
   d <- ggdendro::dendro_data(dendro)$segments
   shapes <- vector("list", nrow(d))


### PR DESCRIPTION
Suppress graphics device initialization when ggdendro::dendro_data() is called in dendro_to_coords(). This prevents unwanted Quartz windows from opening on macOS and Rplots.pdf files from being created during heatmap generation with clustering.

The issue occurred because ggdendro::dendro_data() triggers R's graphics system even though iheatmapr produces htmlwidgets that don't require traditional R graphics devices.

Changes:
- R/dendogram.R: Add device suppression around ggdendro::dendro_data() call
- .gitignore: Add Rplots.pdf to prevent accidental commits of test artifacts

Fixes the issue where calling iheatmap() with clustering options would open graphics devices in applications, particularly noticeable on macOS where it manifests as unwanted Quartz windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)