### PR TITLE
Fix continuous colorbar labels not displaying

### DIFF
--- a/R/colorbars.R
+++ b/R/colorbars.R
@@ -124,13 +124,16 @@ setMethod("make_colorbar",
               grid@x_spacing
             cby <- grid@y_start - ((cb@position - 1) %% grid@nrows) *
               grid@y_spacing
+            tickvals <- tickvals_helper(cb@zmin, cb@zmid, cb@zmax)
             out <- list(x = cbx,
                         y = cby,
                         len = grid@y_length,
                         title = add_wrap_points(cb@title),
                         ypad = 5,
                         thickness = 20,
-                        tickvals = tickvals_helper(cb@zmin, cb@zmid, cb@zmax))
+                        tickvals = tickvals,
+                        ticktext = as.character(tickvals),
+                        tickmode = "array")
             out
           })
 


### PR DESCRIPTION
Fix two issues with numerical covariate colorbars:

1. **Fix missing top and bottom colorbar labels**: Add explicit ticktext and tickmode to continuous colorbars to ensure min/max labels are displayed. Previously only tickvals were set, which could cause plotly to not display the labels consistently.

2. **Related to NAS PR**: This change works in conjunction with NAS changes to suppress hover tooltips on continuous colorbars (where empty ticktext_full is used).

## Changes
- Add `ticktext` and `tickmode = "array"` to continuous colorbar output
- Ensures plotly displays the tick labels as specified

## Testing
- Verified that continuous covariate colorbars now show min/max labels
- Verified hover tooltips are properly suppressed for continuous colorbars

🤖 Generated with [Claude Code](https://claude.com/claude-code)